### PR TITLE
Implement git:rev-list

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -11,4 +11,5 @@
   (:use)
   (:export #:show #:branch #:branches #:commit-parents #:in-repository
            #:with-repository #:current-repository #:show-repository #:git
-           #:tree #:contents #:component))
+           #:tree #:contents #:component
+           #:rev-list))

--- a/porcelain.lisp
+++ b/porcelain.lisp
@@ -132,3 +132,13 @@
   (alexandria:mappend 'cdr (component :parents commit)))
 (defun git:commit-parents (commit)
   (git::parents commit))
+
+(defun git:rev-list (ref-id)
+  "Return the commits reachable from the ref."
+  (labels ((iterate (queue accum)
+             (if (null queue)
+                 accum
+                 (iterate (append (cdr queue)
+                                  (git::parents (ensure-ref (car queue))))
+                   (cons (car queue) accum)))))
+    (iterate (list ref-id) ())))


### PR DESCRIPTION
This is a first stab at implementing rev-list. One thing I haven't done is sort the commits in reverse chronological order. I'm returning the refs as a string as the other commands in porcelain.lisp seem to do that. But imho it would be better to return 'rich' objects instead. For one it would avoid serializing back-and-forth for when we need to do stuff like sort the commits. Plus it allows one to use the inspector.